### PR TITLE
Bugfix 001 entities

### DIFF
--- a/src/entities/Entity.java
+++ b/src/entities/Entity.java
@@ -4,7 +4,8 @@ import exceptions.InvalidEntityNameException;
 
 public abstract class Entity {
     private String name;
-    private int idNumber;
+    private static int instanceCount;
+    private int entityId;
 
     public Entity(String name) throws InvalidEntityNameException {
         this.generateId();
@@ -14,13 +15,13 @@ public abstract class Entity {
         setName(name);
     }
     private void generateId(){
-        idNumber++;
+        this.entityId = ++instanceCount;
     }
     private void setName(String name){
         this.name = name;
     }
     public int getId(){
-        return this.idNumber;
+        return this.entityId;
     }
     public String getName(){
         return this.name;

--- a/test/Entity/EntityClassTests/Sim/entityUnitTest.java
+++ b/test/Entity/EntityClassTests/Sim/entityUnitTest.java
@@ -1,9 +1,14 @@
 package Entity.EntityClassTests.Sim;
 
 import exceptions.InvalidEntityNameException;
+import item.Item;
+import item.food.FoodItem;
 import org.junit.Test;
 import org.junit.Assert;
 import entities.Sim;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -34,6 +39,23 @@ public class entityUnitTest {
         } catch (Exception e){
             assertEquals(EXPECTED_EXCEPTION_MESSAGE_TEXT, e.getMessage());
         }
+    }
+    @Test()
+    public void GenerateId_IdShouldIncrement_EachEntityGetsAUniqueNumberInSequence() throws InvalidEntityNameException {
+        Sim aSim;
+        ArrayList<Item> foodItems;
+        try {
+            foodItems = new ArrayList<Item>();
+            foodItems.add(new FoodItem("Gefilte Fish",null,"A fish made of poached mixture of ground deboned fish, such as carp, whitefish, or pike",false,2,5));
+            foodItems.add(new FoodItem("Corn Chips",null,"Snack food",false,8,2));
+            aSim = new Sim("Tim", foodItems);
+            Assert.assertEquals(1,foodItems.get(0).getId());
+            Assert.assertEquals(2,foodItems.get(1).getId());
+            Assert.assertEquals(3,aSim.getId());
+        } catch(InvalidEntityNameException e){
+                System.out.println(e.getMessage());
+        }
+
     }
 
 }


### PR DESCRIPTION
This PR fixes the entity ID generation.

Previously the integer storing the ID was non-static, and every entity had the ID of 1.

Now the ID is a static int that is incremented by 1 with each new instance of a class that extends from entity.

This is necessary so that classes extending the entity class can properly have a unique ID for debugging purposes once this project gets larger.